### PR TITLE
Transit ported to python 3 AND python 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ For example:
 ## Supported Python versions
 
  * 2.7.X
+ * 3.5.X and greater
 
 
 ## Type Mapping

--- a/setup.py
+++ b/setup.py
@@ -14,13 +14,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from setuptools import setup, find_packages
+from distutils.core import setup
+from pkgutil import walk_packages
+
+import transit
+
+
+def find_packages(path, prefix=""):
+    yield prefix
+    prefix = prefix + "."
+    for _, name, ispkg in walk_packages(path, prefix):
+        if ispkg:
+            yield name
+
 
 setup(name="transit-python",
       version="0.8.279",
       description="Transit marshalling for Python",
       author="Cognitect",
       url="https://github.com/cognitect/transit-python",
-      packages=find_packages(),
-      install_requires=["python-dateutil", "msgpack-python"])
-
+      packages=list(find_packages(transit.__path__, transit.__name__)))

--- a/setup.py
+++ b/setup.py
@@ -1,21 +1,20 @@
 #!/usr/bin/env python
 
-## Copyright 2014 Cognitect. All Rights Reserved.
-##
-## Licensed under the Apache License, Version 2.0 (the "License");
-## you may not use this file except in compliance with the License.
-## You may obtain a copy of the License at
-##
-##      http://www.apache.org/licenses/LICENSE-2.0
-##
-## Unless required by applicable law or agreed to in writing, software
-## distributed under the License is distributed on an "AS-IS" BASIS,
-## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-## See the License for the specific language governing permissions and
-## limitations under the License.
+# Copyright 2014 Cognitect. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from setuptools import setup, find_packages
-import subprocess
 
 setup(name="transit-python",
       version="0.8.279",

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,13 +1,13 @@
-## Copyright 2014 Cognitect. All Rights Reserved.
-##
-## Licensed under the Apache License, Version 2.0 (the "License");
-## you may not use this file except in compliance with the License.
-## You may obtain a copy of the License at
-##
-##      http://www.apache.org/licenses/LICENSE-2.0
-##
-## Unless required by applicable law or agreed to in writing, software
-## distributed under the License is distributed on an "AS-IS" BASIS,
-## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-## See the License for the specific language governing permissions and
-## limitations under the License.
+# Copyright 2014 Cognitect. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/exemplars_test.py
+++ b/tests/exemplars_test.py
@@ -1,83 +1,118 @@
 # -*- coding: utf-8 -*-
-## Copyright 2014 Cognitect. All Rights Reserved.
-##
-## Licensed under the Apache License, Version 2.0 (the "License");
-## you may not use this file except in compliance with the License.
-## You may obtain a copy of the License at
-##
-##      http://www.apache.org/licenses/LICENSE-2.0
-##
-## Unless required by applicable law or agreed to in writing, software
-## distributed under the License is distributed on an "AS-IS" BASIS,
-## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-## See the License for the specific language governing permissions and
-## limitations under the License.
+# Copyright 2014 Cognitect. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import unittest
 
 # then import transit stuff
-from transit.reader import Reader, JsonUnmarshaler, MsgPackUnmarshaler
+from transit.reader import Reader
 from transit.writer import Writer
-from transit.transit_types import Keyword, Symbol, URI, frozendict, TaggedValue, Link, true, false
+from transit.transit_types import Keyword, Symbol, URI, frozendict, TaggedValue, true, false
 from StringIO import StringIO
 from transit.helpers import mapcat
 from helpers import ints_centered_on, hash_of_size, array_of_symbools
 from uuid import UUID
-from datetime import datetime
-import dateutil.tz
+import datetime
+import dateutil
 from math import isnan
+import os
+import sys
+
 
 class ExemplarBaseTest(unittest.TestCase):
     pass
 
+
 def exemplar(name, val):
+
+    # mp files don't work on 64 bit windows
+    def do_test_msgpack():
+        if os.name == 'nt':
+            return False
+        return True
+
+    simppath = '../transit-format/examples/0.8/simple'
+
     class ExemplarTest(ExemplarBaseTest):
 
         def test_json(self):
-            with open("../transit-format/examples/0.8/simple/" + name + ".json", 'r') as stream:
-                data = Reader(protocol="json").read(stream)
+            fname = '{}/{}.json'.format(simppath, name)
+            with open(fname, 'r') as stream:
+                try:
+                    data = Reader(protocol='json').read(stream)
+                except:
+                    print('File "{}" caused exception {}'.format(
+                         fname, sys.exc_info()))
+                    raise
                 self.assertEqual(val, data)
 
         def test_msgpack(self):
-            with open("../transit-format/examples/0.8/simple/" + name + ".mp", 'r') as stream:
-                data = Reader(protocol="msgpack").read(stream)
+            if not do_test_msgpack():
+                return
+            fname = '{}/{}.mp'.format(simppath, name)
+            with open(fname, 'r') as stream:
+                try:
+                    data = Reader(protocol='msgpack').read(stream)
+                except:
+                    print('File "{}" caused exception {}'.format(
+                         fname, sys.exc_info()))
+                    raise
                 self.assertEqual(val, data)
 
         def test_json_verbose(self):
-            with open("../transit-format/examples/0.8/simple/" + name + ".verbose.json", 'r') as stream:
-                data = Reader(protocol="json_verbose").read(stream)
+            fname = '{}/{}.verbose.json'.format(simppath, name)
+            with open(fname, 'r') as stream:
+                try:
+                    data = Reader(protocol='json_verbose').read(stream)
+                except:
+                    print('File "{}" caused exception {}'.format(
+                         fname, sys.exc_info()))
+                    raise
                 self.assertEqual(val, data)
 
         def test_reencode_msgpack(self):
+            if not do_test_msgpack():
+                return
             io = StringIO()
-            writer = Writer(io, protocol="msgpack")
+            writer = Writer(io, protocol='msgpack')
             writer.write(val)
             s = io.getvalue()
             io = StringIO(s)
 
-            reader = Reader(protocol="msgpack")
+            reader = Reader(protocol='msgpack')
             newval = reader.read(io)
             self.assertEqual(val, newval)
 
         def test_reencode_json(self):
             io = StringIO()
-            writer = Writer(io, protocol="json")
+            writer = Writer(io, protocol='json')
             writer.write(val)
             s = io.getvalue()
             # Uncomment when debugging to see what payloads fail
             # print(s)
             io = StringIO(s)
-            reader = Reader(protocol="json")
+            reader = Reader(protocol='json')
             newval = reader.read(io)
             self.assertEqual(val, newval)
 
         # test json verbose
         def test_reencode_json_verbose(self):
             io = StringIO()
-            writer = Writer(io, protocol="json_verbose")
+            writer = Writer(io, protocol='json_verbose')
             writer.write(val)
             s = io.getvalue()
             io = StringIO(s)
-            reader = Reader(protocol="json_verbose")
+            reader = Reader(protocol='json_verbose')
             newval = reader.read(io)
             self.assertEqual(val, newval)
 
@@ -85,24 +120,27 @@ def exemplar(name, val):
             try:
                 return unittest.TestCase.assertEqual(self, val, data)
             except AssertionError as e:
-                if not False in [isnan(v) and isnan(d) or isnan(v) == isnan(d)
-                                 for v, d in zip (val, data)]:
-                    return unittest.TestCase.assertEqual(self, filter(lambda x: not isnan(x), val),
-                                                               filter(lambda x: not isnan(x), data))
+                if False not in [isnan(v) and isnan(d) or isnan(v) == isnan(d)
+                                 for v, d in zip(val, data)]:
+                    return unittest.TestCase.assertEqual(
+                        self,
+                        filter(lambda x: not isnan(x), val),
+                        filter(lambda x: not isnan(x), data))
                 else:
-                    e.args += (name, "failed")
+                    e.args += (name, 'failed')
                     raise
 
-    globals()["test_" + name + "_json"] = ExemplarTest
+    globals()['test_{}_json'.format(name)] = ExemplarTest
 
 ARRAY_SIMPLE = (1, 2, 3)
-ARRAY_MIXED = (0, 1, 2.0, true, false, 'five', Keyword("six"), Symbol("seven"), '~eight', None)
+ARRAY_MIXED = (0, 1, 2.0, true, false, 'five', Keyword('six'), Symbol('seven'), '~eight', None)
 ARRAY_NESTED = (ARRAY_SIMPLE, ARRAY_MIXED)
-SMALL_STRINGS = ("", "a", "ab", "abc", "abcd", "abcde", "abcdef")
+SMALL_STRINGS = ('', 'a', 'ab', 'abc', 'abcd', 'abcde', 'abcdef')
 POWERS_OF_TWO = tuple(map(lambda x: pow(2, x), range(66)))
-INTERESTING_INTS = tuple(mapcat(lambda x: ints_centered_on(x, 2), POWERS_OF_TWO))
+INTERESTING_INTS = tuple(mapcat(lambda x: ints_centered_on(x, 2),
+                                POWERS_OF_TWO))
 
-SYM_STRS = ["a", "ab", "abc", "abcd", "abcde", "a1", "b2", "c3", "a_b"]
+SYM_STRS = ['a', 'ab', 'abc', 'abcd', 'abcde', 'a1', 'b2', 'c3', 'a_b']
 SYMBOLS = tuple(map(Symbol, SYM_STRS))
 KEYWORDS = tuple(map(Keyword, SYM_STRS))
 
@@ -118,122 +156,133 @@ URIS = (
   URI(u'file:///path/to/file.txt'),
   URI(u'http://www.詹姆斯.com/'))
 
-DATES = tuple(map(lambda x: datetime.fromtimestamp(x/1000.0, tz=dateutil.tz.tzutc()),
+epoch_utc = datetime.datetime.utcfromtimestamp(0).replace(
+    tzinfo=dateutil.tz.tzutc())
+
+
+def utc_from_ts(milli_secs):
+    return epoch_utc + datetime.timedelta(seconds=milli_secs/1e3)
+
+DATES = tuple(map(lambda x: utc_from_ts(x),
                   [-6106017600000, 0, 946728000000, 1396909037000]))
 
 SET_SIMPLE = frozenset(ARRAY_SIMPLE)
 SET_MIXED = frozenset(ARRAY_MIXED)
 SET_NESTED = frozenset([SET_SIMPLE, SET_MIXED])
 
-MAP_SIMPLE = frozendict({Keyword("a"): 1,
-                         Keyword("b"): 2,
-                         Keyword("c"): 3})
+MAP_SIMPLE = frozendict({Keyword('a'): 1,
+                         Keyword('b'): 2,
+                         Keyword('c'): 3})
 
-MAP_MIXED = frozendict({Keyword("a"): 1,
-                        Keyword("b"): u"a string",
-                        Keyword("c"): true})
+MAP_MIXED = frozendict({Keyword('a'): 1,
+                        Keyword('b'): u'a string',
+                        Keyword('c'): true})
 
-MAP_NESTED = frozendict({Keyword("simple"): MAP_SIMPLE,
-                         Keyword("mixed"): MAP_MIXED})
+MAP_NESTED = frozendict({Keyword('simple'): MAP_SIMPLE,
+                         Keyword('mixed'): MAP_MIXED})
 
-exemplar("nil", None)
-exemplar("true", true)
-exemplar("false", false)
-exemplar("zero", 0)
-exemplar("one", 1)
-exemplar("one_string", "hello")
-exemplar("one_keyword", Keyword("hello"))
-exemplar("one_symbol", Symbol("hello"))
-exemplar("one_date", datetime.fromtimestamp(946728000000/1000.0, dateutil.tz.tzutc()))
-exemplar("vector_simple", ARRAY_SIMPLE)
-exemplar("vector_empty", ())
-exemplar("vector_mixed", ARRAY_MIXED)
-exemplar("vector_nested", ARRAY_NESTED)
-exemplar("small_strings", SMALL_STRINGS)
-exemplar("strings_tilde", tuple(map(lambda x: "~" + x, SMALL_STRINGS)))
-exemplar("strings_hash", tuple(map(lambda x: "#" + x, SMALL_STRINGS)))
-exemplar("strings_hat", tuple(map(lambda x: "^" + x, SMALL_STRINGS)))
-exemplar("ints", tuple(range(128)))
-exemplar("small_ints", ints_centered_on(0))
-exemplar("ints_interesting", INTERESTING_INTS)
-exemplar("ints_interesting_neg", tuple(map(lambda x: -x, INTERESTING_INTS)))
-exemplar("doubles_small", tuple(map(float, ints_centered_on(0))))
-exemplar("doubles_interesting", (-3.14159, 3.14159, 4E11, 2.998E8, 6.626E-34))
-exemplar("one_uuid", UUIDS[0])
-exemplar("uuids", UUIDS)
-exemplar("one_uri", URIS[0])
-exemplar("uris", URIS)
-exemplar("dates_interesting", DATES)
-exemplar("symbols", SYMBOLS)
-exemplar("keywords", KEYWORDS)
-exemplar("list_simple", ARRAY_SIMPLE)
-exemplar("list_empty", ())
-exemplar("list_mixed", ARRAY_MIXED)
-exemplar("list_nested", ARRAY_NESTED)
-exemplar("set_simple", SET_SIMPLE)
-exemplar("set_empty", set())
-exemplar("set_mixed", SET_MIXED)
-exemplar("set_nested", SET_NESTED)
-exemplar("map_simple", MAP_SIMPLE)
-exemplar("map_mixed", MAP_MIXED)
-exemplar("map_nested", MAP_NESTED)
-exemplar("map_string_keys", {"first": 1, "second": 2, "third": 3})
-exemplar("map_numeric_keys", {1: "one", 2: "two"})
-exemplar("map_vector_keys", frozendict([[(1, 1), "one"],
-                                        [(2, 2), "two"]]))
+exemplar('nil', None)
+exemplar('true', true)
+exemplar('false', false)
+exemplar('zero', 0)
+exemplar('one', 1)
+exemplar('one_string', 'hello')
+exemplar('one_keyword', Keyword('hello'))
+exemplar('one_symbol', Symbol('hello'))
+exemplar('one_date', utc_from_ts(946728000000))
+exemplar('vector_simple', ARRAY_SIMPLE)
+exemplar('vector_empty', ())
+exemplar('vector_mixed', ARRAY_MIXED)
+exemplar('vector_nested', ARRAY_NESTED)
+exemplar('small_strings', SMALL_STRINGS)
+exemplar('strings_tilde', tuple(map(lambda x: '~' + x, SMALL_STRINGS)))
+exemplar('strings_hash', tuple(map(lambda x: '#' + x, SMALL_STRINGS)))
+exemplar('strings_hat', tuple(map(lambda x: '^' + x, SMALL_STRINGS)))
+exemplar('ints', tuple(range(128)))
+exemplar('small_ints', ints_centered_on(0))
+exemplar('ints_interesting', INTERESTING_INTS)
+exemplar('ints_interesting_neg', tuple(map(lambda x: -x, INTERESTING_INTS)))
+exemplar('doubles_small', tuple(map(float, ints_centered_on(0))))
+exemplar('doubles_interesting', (-3.14159, 3.14159, 4E11, 2.998E8, 6.626E-34))
+exemplar('one_uuid', UUIDS[0])
+exemplar('uuids', UUIDS)
+exemplar('one_uri', URIS[0])
+exemplar('uris', URIS)
+exemplar('dates_interesting', DATES)
+exemplar('symbols', SYMBOLS)
+exemplar('keywords', KEYWORDS)
+exemplar('list_simple', ARRAY_SIMPLE)
+exemplar('list_empty', ())
+exemplar('list_mixed', ARRAY_MIXED)
+exemplar('list_nested', ARRAY_NESTED)
+exemplar('set_simple', SET_SIMPLE)
+exemplar('set_empty', set())
+exemplar('set_mixed', SET_MIXED)
+exemplar('set_nested', SET_NESTED)
+exemplar('map_simple', MAP_SIMPLE)
+exemplar('map_mixed', MAP_MIXED)
+exemplar('map_nested', MAP_NESTED)
+exemplar('map_string_keys', {'first': 1, 'second': 2, 'third': 3})
+exemplar('map_numeric_keys', {1: 'one', 2: 'two'})
+exemplar('map_vector_keys', frozendict([[(1, 1), 'one'],
+                                        [(2, 2), 'two']]))
 
 
-exemplar("map_unrecognized_vals", {Keyword("key"): "~Unrecognized"})
-#exemplar("map_unrecognized_keys", )
-exemplar("vector_unrecognized_vals", ("~Unrecognized",))
-exemplar("vector_1935_keywords_repeated_twice", tuple(array_of_symbools(1935, 1935*2)))
-exemplar("vector_1936_keywords_repeated_twice", tuple(array_of_symbools(1936, 1936*2)))
-exemplar("vector_1937_keywords_repeated_twice", tuple(array_of_symbools(1937, 1937*2)))
+exemplar('map_unrecognized_vals', {Keyword('key'): '~Unrecognized'})
+# exemplar('map_unrecognized_keys', )
+exemplar('vector_unrecognized_vals', ('~Unrecognized',))
+exemplar('vector_1935_keywords_repeated_twice',
+         tuple(array_of_symbools(1935, 1935*2)))
+exemplar('vector_1936_keywords_repeated_twice',
+         tuple(array_of_symbools(1936, 1936*2)))
+exemplar('vector_1937_keywords_repeated_twice',
+         tuple(array_of_symbools(1937, 1937*2)))
 
-exemplar("map_10_items", hash_of_size(10))
-exemplar("maps_two_char_sym_keys", ({Symbol("aa"): 1, Symbol("bb"): 2},
-                                    {Symbol("aa"): 3, Symbol("bb"): 4},
-                                    {Symbol("aa"): 5, Symbol("bb"): 6}))
+exemplar('map_10_items', hash_of_size(10))
+exemplar('maps_two_char_sym_keys', ({Symbol('aa'): 1, Symbol('bb'): 2},
+                                    {Symbol('aa'): 3, Symbol('bb'): 4},
+                                    {Symbol('aa'): 5, Symbol('bb'): 6}))
 
-exemplar("maps_three_char_sym_keys", ({Symbol("aaa"): 1, Symbol("bbb"): 2},
-                                      {Symbol("aaa"): 3, Symbol("bbb"): 4},
-                                      {Symbol("aaa"): 5, Symbol("bbb"): 6}))
+exemplar('maps_three_char_sym_keys', ({Symbol('aaa'): 1, Symbol('bbb'): 2},
+                                      {Symbol('aaa'): 3, Symbol('bbb'): 4},
+                                      {Symbol('aaa'): 5, Symbol('bbb'): 6}))
 
-exemplar("maps_four_char_sym_keys", ({Symbol("aaaa"): 1, Symbol("bbbb"): 2},
-                                     {Symbol("aaaa"): 3, Symbol("bbbb"): 4},
-                                     {Symbol("aaaa"): 5, Symbol("bbbb"): 6}))
+exemplar('maps_four_char_sym_keys', ({Symbol('aaaa'): 1, Symbol('bbbb'): 2},
+                                     {Symbol('aaaa'): 3, Symbol('bbbb'): 4},
+                                     {Symbol('aaaa'): 5, Symbol('bbbb'): 6}))
 
-exemplar("maps_two_char_string_keys", ({"aa": 1, "bb": 2},
-                                       {"aa": 3, "bb": 4},
-                                       {"aa": 5, "bb": 6}))
+exemplar('maps_two_char_string_keys', ({'aa': 1, 'bb': 2},
+                                       {'aa': 3, 'bb': 4},
+                                       {'aa': 5, 'bb': 6}))
 
-exemplar("maps_three_char_string_keys", ({"aaa": 1, "bbb": 2},
-                                         {"aaa": 3, "bbb": 4},
-                                         {"aaa": 5, "bbb": 6}))
+exemplar('maps_three_char_string_keys', ({'aaa': 1, 'bbb': 2},
+                                         {'aaa': 3, 'bbb': 4},
+                                         {'aaa': 5, 'bbb': 6}))
 
-exemplar("maps_four_char_string_keys", ({"aaaa": 1, "bbbb": 2},
-                                        {"aaaa": 3, "bbbb": 4},
-                                        {"aaaa": 5, "bbbb": 6}))
+exemplar('maps_four_char_string_keys', ({'aaaa': 1, 'bbbb': 2},
+                                        {'aaaa': 3, 'bbbb': 4},
+                                        {'aaaa': 5, 'bbbb': 6}))
 
-exemplar("maps_unrecognized_keys", (TaggedValue("abcde", Keyword("anything")),
-                                   TaggedValue("fghij", Keyword("anything-else")),))
+exemplar('maps_unrecognized_keys',
+         (TaggedValue('abcde', Keyword('anything')),
+          TaggedValue('fghij', Keyword('anything-else')),))
 
-exemplar("vector_special_numbers", (float("nan"), float("inf"), float("-inf")))
+exemplar('vector_special_numbers', (float('nan'), float('inf'), float('-inf')))
 
 # Doesn't exist in simple examples but gave me tests to verify Link.
-#exemplar("link", Link("http://www.blah.com", "test", "test", "link", "test"))
+# exemplar('link', Link('http://www.blah.com', 'test', 'test', 'link', 'test'))
+
 
 def make_hash_exemplar(n):
-    exemplar("map_%s_nested" % (n,), {Keyword("f"): hash_of_size(n),
-                                      Keyword("s"): hash_of_size(n)})
+    exemplar('map_%s_nested' % (n,), {Keyword('f'): hash_of_size(n),
+                                      Keyword('s'): hash_of_size(n)})
 map(make_hash_exemplar, [10, 1935, 1936, 1937])
 
-if __name__=='__main__':
+if __name__ == '__main__':
     unittest.main()
-    #import cProfile
-    #import pstats
-    #cProfile.run('unittest.main()', 'exemptests')
-    #p = pstats.Stats('exemptests')
-    #p.sort_stats('time')
-    #p.print_stats()
-
+    # import cProfile
+    # import pstats
+    # cProfile.run('unittest.main()', 'exemptests')
+    # p = pstats.Stats('exemptests')
+    # p.sort_stats('time')
+    # p.print_stats()

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -14,7 +14,7 @@
 
 from transit.transit_types import Keyword, frozendict
 from transit.helpers import cycle, take
-from itertools import izip
+import six
 
 
 def ints_centered_on(m, n=5):
@@ -30,4 +30,4 @@ def array_of_symbools(m, n=None):
 
 
 def hash_of_size(n):
-    return frozendict(izip(array_of_symbools(n), range(0, n+1)))
+    return frozendict(six.moves.zip(array_of_symbools(n), range(0, n+1)))

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,20 +1,21 @@
-## Copyright 2014 Cognitect. All Rights Reserved.
-##
-## Licensed under the Apache License, Version 2.0 (the "License");
-## you may not use this file except in compliance with the License.
-## You may obtain a copy of the License at
-##
-##      http://www.apache.org/licenses/LICENSE-2.0
-##
-## Unless required by applicable law or agreed to in writing, software
-## distributed under the License is distributed on an "AS-IS" BASIS,
-## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-## See the License for the specific language governing permissions and
-## limitations under the License.
+# Copyright 2014 Cognitect. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-from transit.transit_types import Symbol, Keyword, frozendict
-from transit.helpers import cycle, take, pairs
+from transit.transit_types import Keyword, frozendict
+from transit.helpers import cycle, take
 from itertools import izip
+
 
 def ints_centered_on(m, n=5):
     return tuple(range(m - n, m + n + 1))

--- a/tests/regression.py
+++ b/tests/regression.py
@@ -1,16 +1,16 @@
-## Copyright 2014 Cognitect. All Rights Reserved.
-##
-## Licensed under the Apache License, Version 2.0 (the "License");
-## you may not use this file except in compliance with the License.
-## You may obtain a copy of the License at
-##
-##      http://www.apache.org/licenses/LICENSE-2.0
-##
-## Unless required by applicable law or agreed to in writing, software
-## distributed under the License is distributed on an "AS-IS" BASIS,
-## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-## See the License for the specific language governing permissions and
-## limitations under the License.
+# Copyright 2014 Cognitect. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # This test suite verifies that issues corrected remain corrected.
 import unittest
@@ -18,12 +18,14 @@ import json
 from transit.reader import Reader
 from transit.writer import Writer
 from transit.class_hash import ClassDict
-from transit.transit_types import Symbol, frozendict, true, false, Keyword, Named
+from transit.transit_types import Symbol, frozendict, true, false, Keyword
 from decimal import Decimal
 from StringIO import StringIO
 
+
 class RegressionBaseTest(unittest.TestCase):
     pass
+
 
 def regression(name, value):
     class RegressionTest(RegressionBaseTest):
@@ -31,22 +33,24 @@ def regression(name, value):
         def test_roundtrip(self):
             in_data = value
             io = StringIO()
-            w = Writer(io, "json")
+            w = Writer(io, 'json')
             w.write(in_data)
-            r = Reader("json")
+            r = Reader('json')
             out_data = r.read(StringIO(io.getvalue()))
             self.assertEqual(in_data, out_data)
 
-    globals()["test_" + name + "_json"] = RegressionTest
+    globals()['test_{}_json'.format(name)] = RegressionTest
 
-regression("cache_consistency", ({"Problem?":true},
-                                  Symbol("Here"),
-                                  Symbol("Here")))
-regression("one_pair_frozendict", frozendict({"a":1}))
-regression("json_int_max", (2**53+100, 2**63+100))
-regression("newline_in_string", "a\nb")
-regression("big_decimal", Decimal("190234710272.2394720347203642836434"))
-regression("dict_in_set", frozenset(frozendict({"test":"case"})))
+regression('cache_consistency',
+           ({'Problem?': true},
+            Symbol('Here'),
+            Symbol('Here')))
+regression('one_pair_frozendict', frozendict({'a': 1}))
+regression('json_int_max', (2**53+100, 2**63+100))
+regression('newline_in_string', 'a\nb')
+regression('big_decimal', Decimal('190234710272.2394720347203642836434'))
+regression('dict_in_set', frozenset(frozendict({'test': 'case'})))
+
 
 def json_verbose_cache_bug():
     class JsonVerboseCacheBug(RegressionBaseTest):
@@ -56,31 +60,35 @@ def json_verbose_cache_bug():
 
         def test_key_not_cached(self):
             io = StringIO()
-            w = Writer(io, "json_verbose")
-            w.write([{'myKey1':42},{'myKey1':42}])
-            self.assertEqual(io.getvalue(), u"[{\"myKey1\":42},{\"myKey1\":42}]")
+            w = Writer(io, 'json_verbose')
+            w.write([{'myKey1': 42}, {'myKey1': 42}])
+            self.assertEqual(io.getvalue(),
+                             u"[{\"myKey1\":42},{\"myKey1\":42}]")
 
-    globals()["test_json_verbose_cache_bug"] = JsonVerboseCacheBug
+    globals()['test_json_verbose_cache_bug'] = JsonVerboseCacheBug
 
 json_verbose_cache_bug()
+
 
 def json_int_boundary(value, expected_type):
     class JsonIntBoundaryTest(unittest.TestCase):
 
         def test_max_is_number(self):
-            for protocol in ("json", "json_verbose"):
+            for protocol in ('json', 'json_verbose'):
                 io = StringIO()
                 w = Writer(io, protocol)
                 w.write([value])
-                actual_type = type(json.loads(io.getvalue())[0])
+                read_val = json.loads(io.getvalue())[0]
+                actual_type = type(read_val)
                 self.assertEqual(expected_type, actual_type)
 
-    globals()["test_json_int_boundary_" + str(value)] = JsonIntBoundaryTest
+    globals()['test_json_int_boundary_{}'.format(value)] = JsonIntBoundaryTest
 
 json_int_boundary(2**53-1, int)
 json_int_boundary(2**53, unicode)
 json_int_boundary(-2**53+1, int)
 json_int_boundary(-2**53, unicode)
+
 
 class BooleanTest(unittest.TestCase):
     """Even though we're roundtripping transit_types.true and
@@ -90,7 +98,7 @@ class BooleanTest(unittest.TestCase):
     Boolean values.
     """
     def test_write_bool(self):
-        for protocol in ("json", "json_verbose", "msgpack"):
+        for protocol in ('json', 'json_verbose', 'msgpack'):
             io = StringIO()
             w = Writer(io, protocol)
             w.write((True, False))
@@ -114,13 +122,19 @@ class BooleanTest(unittest.TestCase):
         assert true and true
         assert not (false and false)
 
+
 # Helper classes for inheritance unit test.
 class parent(object):
     pass
+
+
 class child(parent):
     pass
+
+
 class grandchild(child):
     pass
+
 
 class ClassDictInheritanceTest(unittest.TestCase):
     """ Fix from issue #18: class_hash should iterate over all ancestors
@@ -128,8 +142,9 @@ class ClassDictInheritanceTest(unittest.TestCase):
     """
     def test_inheritance(self):
         cd = ClassDict()
-        cd[parent] = "test"
+        cd[parent] = 'test'
         assert grandchild in cd
+
 
 class NamedTests(unittest.TestCase):
     """ Verify behavior for newly introduced built-in Named name/namespace
@@ -137,24 +152,24 @@ class NamedTests(unittest.TestCase):
     transit_types.Keyword and transit_types.Symbol.
     """
     def test_named(self):
-        k = Keyword("blah")
-        s = Symbol("blah")
-        assert k.name == "blah"
-        assert s.name == "blah"
+        k = Keyword('blah')
+        s = Symbol('blah')
+        assert k.name == 'blah'
+        assert s.name == 'blah'
 
     def test_namespaced(self):
-        k = Keyword("ns/name")
-        s = Symbol("ns/name")
-        assert k.name == "name"
-        assert s.name == "name"
-        assert k.namespace == "ns"
-        assert s.namespace == "ns"
+        k = Keyword('ns/name')
+        s = Symbol('ns/name')
+        assert k.name == 'name'
+        assert s.name == 'name'
+        assert k.namespace == 'ns'
+        assert s.namespace == 'ns'
 
     def test_slash(self):
-        k = Keyword("/")
-        s = Symbol("/")
-        assert k.name == "/"
-        assert s.name == "/"
+        k = Keyword('/')
+        s = Symbol('/')
+        assert k.name == '/'
+        assert s.name == '/'
         assert k.namespace is None
         assert s.namespace is None
 

--- a/tests/regression.py
+++ b/tests/regression.py
@@ -21,6 +21,7 @@ from transit.class_hash import ClassDict
 from transit.transit_types import Symbol, frozendict, true, false, Keyword
 from decimal import Decimal
 from StringIO import StringIO
+import six
 
 
 class RegressionBaseTest(unittest.TestCase):
@@ -85,9 +86,9 @@ def json_int_boundary(value, expected_type):
     globals()['test_json_int_boundary_{}'.format(value)] = JsonIntBoundaryTest
 
 json_int_boundary(2**53-1, int)
-json_int_boundary(2**53, unicode)
+json_int_boundary(2**53, six.text_type)
 json_int_boundary(-2**53+1, int)
-json_int_boundary(-2**53, unicode)
+json_int_boundary(-2**53, six.text_type)
 
 
 class BooleanTest(unittest.TestCase):

--- a/tests/seattle_benchmark.py
+++ b/tests/seattle_benchmark.py
@@ -1,21 +1,23 @@
-## Copyright 2014 Cognitect. All Rights Reserved.
-##
-## Licensed under the Apache License, Version 2.0 (the "License");
-## you may not use this file except in compliance with the License.
-## You may obtain a copy of the License at
-##
-##      http://www.apache.org/licenses/LICENSE-2.0
-##
-## Unless required by applicable law or agreed to in writing, software
-## distributed under the License is distributed on an "AS-IS" BASIS,
-## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-## See the License for the specific language governing permissions and
-## limitations under the License.
+# Copyright 2014 Cognitect. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from transit.reader import JsonUnmarshaler
 import json
 import time
 from StringIO import StringIO
+
+
 def run_tests(data):
     datas = StringIO(data)
     t = time.time()
@@ -26,26 +28,26 @@ def run_tests(data):
     json.load(datas)
     ett = time.time()
     read_delta = (et - t) * 1000.0
-    print "Done: " + str(read_delta) + "  --  raw JSON in: " + str((ett - tt) * 1000.0)
+    print('Done: {}  --  raw JSON in: {}'.format(
+        read_delta, (ett - tt) * 1000.0))
     return read_delta
 
 
-seattle_dir = "../transit-format/examples/0.8/"
+seattle_dir = '../transit-format/examples/0.8/'
 means = {}
-for jsonfile in [seattle_dir + "example.json", 
-                 seattle_dir + "example.verbose.json"]:
-    data = ""
+for jsonfile in ['{}example.json'.format(seattle_dir),
+                 '{}example.verbose.json'.format(seattle_dir)]:
+    data = ''
     with open(jsonfile, 'r') as fd:
         data = fd.read()
 
-    print("-"*50)
-    print("Running " + jsonfile)
-    print("-"*50)
+    print('-'*50)
+    print('Running {}'.format(jsonfile))
+    print('-'*50)
 
     runs = 100
     deltas = [run_tests(data) for x in range(runs)]
     means[jsonfile] = sum(deltas)/runs
 
 for jsonfile, mean in means.items():
-    print "\nMean for" + jsonfile + ": "+str(mean)
-
+    print('\nMean for{}: {}'.format(jsonfile, mean))

--- a/transit/__init__.py
+++ b/transit/__init__.py
@@ -1,13 +1,13 @@
-## Copyright 2014 Cognitect. All Rights Reserved.
-##
-## Licensed under the Apache License, Version 2.0 (the "License");
-## you may not use this file except in compliance with the License.
-## You may obtain a copy of the License at
-##
-##      http://www.apache.org/licenses/LICENSE-2.0
-##
-## Unless required by applicable law or agreed to in writing, software
-## distributed under the License is distributed on an "AS-IS" BASIS,
-## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-## See the License for the specific language governing permissions and
-## limitations under the License.
+# Copyright 2014 Cognitect. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/transit/class_hash.py
+++ b/transit/class_hash.py
@@ -1,16 +1,16 @@
-## Copyright 2014 Cognitect. All Rights Reserved.
-##
-## Licensed under the Apache License, Version 2.0 (the "License");
-## you may not use this file except in compliance with the License.
-## You may obtain a copy of the License at
-##
-##      http://www.apache.org/licenses/LICENSE-2.0
-##
-## Unless required by applicable law or agreed to in writing, software
-## distributed under the License is distributed on an "AS-IS" BASIS,
-## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-## See the License for the specific language governing permissions and
-## limitations under the License.
+# Copyright 2014 Cognitect. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # Hash that looks up class keys with inheritance.
 import collections
@@ -38,7 +38,7 @@ class ClassDict(collections.MutableMapping):
                 value = t in self.store and self.store[t]
                 if value:
                     return value
-            raise KeyError("No handler found for: " + str(key))
+            raise KeyError('No handler found for: {}'.format(key))
 
     def __setitem__(self, key, value):
         self.store[key] = value

--- a/transit/constants.py
+++ b/transit/constants.py
@@ -1,16 +1,16 @@
-## Copyright 2014 Cognitect. All Rights Reserved.
-##
-## Licensed under the Apache License, Version 2.0 (the "License");
-## you may not use this file except in compliance with the License.
-## You may obtain a copy of the License at
-##
-##      http://www.apache.org/licenses/LICENSE-2.0
-##
-## Unless required by applicable law or agreed to in writing, software
-## distributed under the License is distributed on an "AS-IS" BASIS,
-## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-## See the License for the specific language governing permissions and
-## limitations under the License.
+# Copyright 2014 Cognitect. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # These are constants used throughout the source code.
 # They refer to Tag codes used when reading and wrting transit.

--- a/transit/decoder.py
+++ b/transit/decoder.py
@@ -1,16 +1,16 @@
-## Copyright 2014 Cognitect. All Rights Reserved.
-##
-## Licensed under the Apache License, Version 2.0 (the "License");
-## you may not use this file except in compliance with the License.
-## You may obtain a copy of the License at
-##
-##      http://www.apache.org/licenses/LICENSE-2.0
-##
-## Unless required by applicable law or agreed to in writing, software
-## distributed under the License is distributed on an "AS-IS" BASIS,
-## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-## See the License for the specific language governing permissions and
-## limitations under the License.
+# Copyright 2014 Cognitect. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import transit_types
 from constants import MAP_AS_ARR, ESC, SUB, RES
@@ -85,13 +85,13 @@ class Decoder(object):
         tp = type(node)
         if tp is unicode:
             return self.decode_string(node, cache, as_map_key)
-        elif tp is dict or tp is OrderedDict:
-            return self.decode_hash(node, cache, as_map_key)
-        elif tp is list:
-            return self.decode_list(node, cache, as_map_key)
-        elif tp is str:
+        if tp is str:
             return self.decode_string(unicode(node, "utf-8"), cache, as_map_key)
-        elif tp is bool:
+        if tp is dict or tp is OrderedDict:
+            return self.decode_hash(node, cache, as_map_key)
+        if tp is list:
+            return self.decode_list(node, cache, as_map_key)
+        if tp is bool:
             return true if node else false
         return node
 
@@ -155,7 +155,8 @@ class Decoder(object):
             if isinstance(key, Tag):
                 return self.decode_tag(key.tag,
                                        self._decode(value, cache, as_map_key))
-        return transit_types.frozendict({key: self._decode(value, cache, False)})
+        return transit_types.frozendict(
+            {key: self._decode(value, cache, False)})
 
     def parse_string(self, string, cache, as_map_key):
         if string.startswith(ESC):

--- a/transit/helpers.py
+++ b/transit/helpers.py
@@ -1,16 +1,16 @@
-## Copyright 2014 Cognitect. All Rights Reserved.
-##
-## Licensed under the Apache License, Version 2.0 (the "License");
-## you may not use this file except in compliance with the License.
-## You may obtain a copy of the License at
-##
-##      http://www.apache.org/licenses/LICENSE-2.0
-##
-## Unless required by applicable law or agreed to in writing, software
-## distributed under the License is distributed on an "AS-IS" BASIS,
-## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-## See the License for the specific language governing permissions and
-## limitations under the License.
+# Copyright 2014 Cognitect. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import itertools
 

--- a/transit/helpers.py
+++ b/transit/helpers.py
@@ -13,14 +13,15 @@
 # limitations under the License.
 
 import itertools
+import six
 
 
 def mapcat(f, i):
-    return itertools.chain.from_iterable(itertools.imap(f, i))
+    return itertools.chain.from_iterable(six.moves.map(f, i))
 
 
 def pairs(i):
-    return itertools.izip(*[iter(i)] * 2)
+    return six.moves.zip(*[iter(i)] * 2)
 
 
 cycle = itertools.cycle

--- a/transit/read_handlers.py
+++ b/transit/read_handlers.py
@@ -12,14 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import transit_types
+from transit import transit_types
 import uuid
 import ctypes
 import dateutil.parser
 import datetime
 import dateutil.tz
-from helpers import pairs
+from transit.helpers import pairs
 from decimal import Decimal
+import six
 
 # Read handlers are used by the decoder when parsing/reading in Transit
 # data and returning Python objects
@@ -64,7 +65,8 @@ class BooleanHandler(object):
 class IntHandler(object):
     @staticmethod
     def from_rep(v):
-        return int(v)
+        d = int(v) if six.PY3 else long(v)
+        return d
 
 
 class FloatHandler(object):
@@ -77,7 +79,7 @@ class UuidHandler(object):
     @staticmethod
     def from_rep(u):
         """Given a string, return a UUID object."""
-        if isinstance(u, basestring):
+        if isinstance(u, six.string_types):
             return uuid.UUID(u)
 
         # hack to remove signs
@@ -99,11 +101,12 @@ class DateHandler(object):
 
     @staticmethod
     def from_rep(d):
-        if isinstance(d, (long, int)):
+        if isinstance(d, six.integer_types):
             return DateHandler._convert_timestamp(d)
         if "T" in d:
             return dateutil.parser.parse(d)
-        return DateHandler._convert_timestamp(long(d))
+        v = int(d) if six.PY3 else long(d)
+        return DateHandler._convert_timestamp(v)
 
     @staticmethod
     def _convert_timestamp(ms):
@@ -114,7 +117,7 @@ class DateHandler(object):
 class BigIntegerHandler(object):
     @staticmethod
     def from_rep(d):
-        return long(d)
+        return int(d)
 
 
 class LinkHandler(object):

--- a/transit/read_handlers.py
+++ b/transit/read_handlers.py
@@ -1,16 +1,16 @@
-## Copyright 2014 Cognitect. All Rights Reserved.
-##
-## Licensed under the Apache License, Version 2.0 (the "License");
-## you may not use this file except in compliance with the License.
-## You may obtain a copy of the License at
-##
-##      http://www.apache.org/licenses/LICENSE-2.0
-##
-## Unless required by applicable law or agreed to in writing, software
-## distributed under the License is distributed on an "AS-IS" BASIS,
-## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-## See the License for the specific language governing permissions and
-## limitations under the License.
+# Copyright 2014 Cognitect. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import transit_types
 import uuid
@@ -21,8 +21,8 @@ import dateutil.tz
 from helpers import pairs
 from decimal import Decimal
 
-## Read handlers are used by the decoder when parsing/reading in Transit
-## data and returning Python objects
+# Read handlers are used by the decoder when parsing/reading in Transit
+# data and returning Python objects
 
 
 class DefaultHandler(object):
@@ -94,6 +94,9 @@ class UriHandler(object):
 
 
 class DateHandler(object):
+    epoch_utc = datetime.datetime.utcfromtimestamp(0).replace(
+        tzinfo=dateutil.tz.tzutc())
+
     @staticmethod
     def from_rep(d):
         if isinstance(d, (long, int)):
@@ -105,7 +108,7 @@ class DateHandler(object):
     @staticmethod
     def _convert_timestamp(ms):
         """Given a timestamp in ms, return a DateTime object."""
-        return datetime.datetime.fromtimestamp(ms/1000.0, dateutil.tz.tzutc())
+        return DateHandler.epoch_utc + datetime.timedelta(seconds=ms / 1e3)
 
 
 class BigIntegerHandler(object):

--- a/transit/reader.py
+++ b/transit/reader.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 import json
-import sosjson
+from transit import sosjson
 import msgpack
-from decoder import Decoder
+from transit.decoder import Decoder
 from collections import OrderedDict
 
 
@@ -67,8 +67,9 @@ class JsonUnmarshaler(object):
         self.decoder = Decoder()
 
     def load(self, stream):
-        return self.decoder.decode(json.load(stream,
-                                             object_pairs_hook=OrderedDict))
+        jdata = json.load(stream, object_pairs_hook=OrderedDict)
+        ddata = self.decoder.decode(jdata)
+        return ddata
 
     def loadeach(self, stream):
         for o in sosjson.items(stream, object_pairs_hook=OrderedDict):

--- a/transit/reader.py
+++ b/transit/reader.py
@@ -1,16 +1,16 @@
-## Copyright 2014 Cognitect. All Rights Reserved.
-##
-## Licensed under the Apache License, Version 2.0 (the "License");
-## you may not use this file except in compliance with the License.
-## You may obtain a copy of the License at
-##
-##      http://www.apache.org/licenses/LICENSE-2.0
-##
-## Unless required by applicable law or agreed to in writing, software
-## distributed under the License is distributed on an "AS-IS" BASIS,
-## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-## See the License for the specific language governing permissions and
-## limitations under the License.
+# Copyright 2014 Cognitect. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import json
 import sosjson
@@ -24,16 +24,16 @@ class Reader(object):
     Python objects.  During initialization, you must specify the protocol used
     for unmarshalling the data- json or msgpack.
     """
-    def __init__(self, protocol="json"):
-        if protocol in ("json", "json_verbose"):
+    def __init__(self, protocol='json'):
+        if protocol in ('json', 'json_verbose'):
             self.reader = JsonUnmarshaler()
-        elif protocol == "msgpack":
+        elif protocol == 'msgpack':
             self.reader = MsgPackUnmarshaler()
             self.unpacker = self.reader.unpacker
         else:
-            raise ValueError("'" + protocol + "' is not a supported. " +
-                             "Protocol must be:" +
-                             "'json', 'json_verbose', or 'msgpack'.")
+            raise ValueError(
+                "'{}' is not a supported. Protocol must be:"
+                "'json', 'json_verbose', or 'msgpack'.".format(protocol))
 
     def read(self, stream):
         """Given a readable file descriptor object (something `load`able by
@@ -84,8 +84,8 @@ class MsgPackUnmarshaler(object):
         self.unpacker = msgpack.Unpacker(object_pairs_hook=OrderedDict)
 
     def load(self, stream):
-        return self.decoder.decode(msgpack.load(stream,
-                                                object_pairs_hook=OrderedDict))
+        mydata = msgpack.load(stream, object_pairs_hook=OrderedDict)
+        return self.decoder.decode(mydata)
 
     def loadeach(self, stream):
         for o in self.unpacker:

--- a/transit/rolling_cache.py
+++ b/transit/rolling_cache.py
@@ -1,16 +1,16 @@
-## Copyright 2014 Cognitect. All Rights Reserved.
-##
-## Licensed under the Apache License, Version 2.0 (the "License");
-## you may not use this file except in compliance with the License.
-## You may obtain a copy of the License at
-##
-##      http://www.apache.org/licenses/LICENSE-2.0
-##
-## Unless required by applicable law or agreed to in writing, software
-## distributed under the License is distributed on an "AS-IS" BASIS,
-## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-## See the License for the specific language governing permissions and
-## limitations under the License.
+# Copyright 2014 Cognitect. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from constants import SUB, MAP_AS_ARR
 
@@ -42,8 +42,8 @@ def decode_key(s):
 
 def is_cacheable(string, as_map_key=False):
     return string and len(string) >= MIN_SIZE_CACHEABLE \
-                  and (as_map_key \
-                  or (string[:2] in ["~#", "~$", "~:"]))
+                  and (as_map_key
+                       or (string[:2] in ["~#", "~$", "~:"]))
 
 
 class RollingCache(object):

--- a/transit/rolling_cache.py
+++ b/transit/rolling_cache.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from constants import SUB, MAP_AS_ARR
+from transit.constants import SUB, MAP_AS_ARR
 
 FIRST_ORD = 48
 CACHE_CODE_DIGITS = 44

--- a/transit/sosjson.py
+++ b/transit/sosjson.py
@@ -1,16 +1,17 @@
-## copyright 2014 cognitect. all rights reserved.
-##
-## licensed under the apache license, version 2.0 (the "license");
-## you may not use this file except in compliance with the license.
-## you may obtain a copy of the license at
-##
-##      http://www.apache.org/licenses/license-2.0
-##
-## unless required by applicable law or agreed to in writing, software
-## distributed under the license is distributed on an "as-is" basis,
-## without warranties or conditions of any kind, either express or implied.
-## see the license for the specific language governing permissions and
-## limitations under the license.
+# copyright 2014 cognitect. all rights reserved.
+#
+# licensed under the apache license, version 2.0 (the "license");
+# you may not use this file except in compliance with the license.
+# you may obtain a copy of the license at
+#
+#      http://www.apache.org/licenses/license-2.0
+#
+# unless required by applicable law or agreed to in writing, software
+# distributed under the license is distributed on an "as-is" basis,
+# without warranties or conditions of any kind, either express or implied.
+# see the license for the specific language governing permissions and
+# limitations under the license.
+
 # Simple object streaming in Python - just reads one complete JSON object
 # at a time and returns json.loads of that string.
 

--- a/transit/transit_types.py
+++ b/transit/transit_types.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 from collections import Mapping, Hashable
+from functools import reduce
+import six
 
 
 class Named(object):
@@ -38,7 +40,7 @@ class Named(object):
 
 class Keyword(Named):
     def __init__(self, value):
-        assert isinstance(value, basestring)
+        assert isinstance(value, six.string_types)
         self.str = value
         self.hv = value.__hash__()
 
@@ -63,7 +65,7 @@ class Keyword(Named):
 
 class Symbol(Named):
     def __init__(self, value):
-        assert isinstance(value, basestring)
+        assert isinstance(value, six.string_types)
         self.str = value
         self.hv = value.__hash__()
 

--- a/transit/transit_types.py
+++ b/transit/transit_types.py
@@ -1,16 +1,16 @@
-## Copyright 2014 Cognitect. All Rights Reserved.
-##
-## Licensed under the Apache License, Version 2.0 (the "License");
-## you may not use this file except in compliance with the License.
-## You may obtain a copy of the License at
-##
-##      http://www.apache.org/licenses/LICENSE-2.0
-##
-## Unless required by applicable law or agreed to in writing, software
-## distributed under the License is distributed on an "AS-IS" BASIS,
-## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-## See the License for the specific language governing permissions and
-## limitations under the License.
+# Copyright 2014 Cognitect. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from collections import Mapping, Hashable
 
@@ -55,7 +55,7 @@ class Keyword(Named):
         return mp[self]
 
     def __repr__(self):
-        return "<Keyword " + self.str + ">"
+        return "<Keyword {}>".format(self.str)
 
     def __str__(self):
         return self.str

--- a/transit/write_handlers.py
+++ b/transit/write_handlers.py
@@ -1,16 +1,16 @@
-## Copyright 2014 Cognitect. All Rights Reserved.
-##
-## Licensed under the Apache License, Version 2.0 (the "License");
-## you may not use this file except in compliance with the License.
-## You may obtain a copy of the License at
-##
-##      http://www.apache.org/licenses/LICENSE-2.0
-##
-## Unless required by applicable law or agreed to in writing, software
-## distributed under the License is distributed on an "AS-IS" BASIS,
-## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-## See the License for the specific language governing permissions and
-## limitations under the License.
+# Copyright 2014 Cognitect. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import uuid
 import datetime
@@ -18,11 +18,11 @@ import struct
 from class_hash import ClassDict
 from transit_types import Keyword, Symbol, URI, frozendict, TaggedValue, Link, Boolean
 from decimal import Decimal
-from dateutil import tz
+import dateutil
 from math import isnan
 
-## This file contains Write Handlers - all the top-level objects used when
-## writing Transit data.  These object must all be immutable and pickleable.
+# This file contains Write Handlers - all the top-level objects used when
+# writing Transit data.  These object must all be immutable and pickleable.
 
 
 class TaggedMap(object):
@@ -230,7 +230,9 @@ class UriHandler(object):
 
 
 class DateTimeHandler(object):
-    epoch = datetime.datetime(1970, 1, 1).replace(tzinfo=tz.tzutc())
+    "time zero in UTC"
+    epoch_utc = datetime.datetime.utcfromtimestamp(0).replace(
+        tzinfo=dateutil.tz.tzutc())
 
     @staticmethod
     def tag(_):
@@ -238,8 +240,9 @@ class DateTimeHandler(object):
 
     @staticmethod
     def rep(d):
-        td = d - DateTimeHandler.epoch
-        return int((td.microseconds + (td.seconds + td.days * 24 * 3600) * 10**6) / 1e3)
+        td = d - DateTimeHandler.epoch_utc
+        return int((td.microseconds +
+                    (td.seconds + td.days * 24 * 3600) * 10**6) / 1e3)
 
     @staticmethod
     def verbose_handler():

--- a/transit/writer.py
+++ b/transit/writer.py
@@ -14,12 +14,23 @@
 
 import msgpack
 import re
-from constants import SUB, ESC, RES, MAP_AS_ARR, QUOTE
-from rolling_cache import RollingCache
-from write_handlers import WriteHandler
-from transit_types import TaggedValue
+from transit.constants import SUB, ESC, RES, MAP_AS_ARR, QUOTE
+from transit.rolling_cache import RollingCache
+from transit.write_handlers import WriteHandler
+from transit.transit_types import TaggedValue
+import six
 
-JSON_ESCAPED_CHARS = set([unichr(c) for c in range(0x20)] + ['\\', '\n'])
+JSON_ESCAPED_CHARS = set([six.unichr(c) for c in range(0x20)] + ['\\', '\n'])
+
+
+def json_esc(s):
+    sesc = "".join(
+        [
+            (c.encode('unicode_escape'))
+            if c in JSON_ESCAPED_CHARS
+            else c for c in s
+        ]).replace("\"", "\\\"")
+    return sesc
 
 
 class Writer(object):
@@ -134,7 +145,8 @@ class Marshaler(object):
 
     def emit_array(self, a, _, cache):
         self.emit_array_start(len(a))
-        map(lambda x: self.marshal(x, False, cache), a)
+        for x in a:
+            self.marshal(x, False, cache)
         self.emit_array_end()
 
     # use map as object from above, have to overwrite default parser.
@@ -160,11 +172,11 @@ class Marshaler(object):
     def emit_encoded(self, tag, handler, obj, as_map_key, cache):
         rep = handler.rep(obj)
         if len(tag) == 1:
-            if isinstance(rep, basestring):
+            if isinstance(rep, six.string_types):
                 self.emit_string(ESC, tag, rep, as_map_key, cache)
             elif as_map_key or self.opts['prefer_strings']:
                 rep = handler.string_rep(obj)
-                if isinstance(rep, basestring):
+                if isinstance(rep, six.string_types):
                     self.emit_string(ESC, tag, rep, as_map_key, cache)
                 else:
                     raise AssertionError(
@@ -372,15 +384,9 @@ class JsonMarshaler(Marshaler):
     def emit_object(self, obj, as_map_key=False):
         tp = type(obj)
         self.write_sep()
-        if tp is str or tp is unicode:
-            self.io.write(u"\"")
-
-            # escapes in-line for perf
-            self.io.write(u"".join([(c.encode('unicode_escape'))
-                                    if c in JSON_ESCAPED_CHARS
-                                    else c for c in obj]).replace("\"", "\\\""))
-            self.io.write(u"\"")
-        elif tp is int or tp is long or tp is float:
+        if isinstance(obj, six.string_types):
+            self.io.write(u'\"{}\"'.format(json_esc(obj)))
+        elif tp is float or tp is int or (six.PY2 and tp is long):
             self.io.write(str(obj))
         elif tp is bool:
             self.io.write(u'true' if obj else u'false')
@@ -396,7 +402,7 @@ class VerboseSettings(object):
     """
     @staticmethod
     def _verbose_handlers(handlers):
-        for k, v in handlers.iteritems():
+        for k, v in six.iteritems(handlers):
             if hasattr(v, 'verbose_handler'):
                 handlers[k] = v.verbose_handler()
         return handlers
@@ -405,7 +411,7 @@ class VerboseSettings(object):
         self.handlers = self._verbose_handlers(WriteHandler())
 
     def emit_string(self, prefix, tag, string, as_map_key, cache):
-        return self.emit_object(unicode(prefix) + tag + string, as_map_key)
+        return self.emit_object(six.text_type(prefix) + tag + string, as_map_key)
 
     def emit_map(self, m, _, cache):
         self.emit_map_start(len(m))


### PR DESCRIPTION
Transit ported to python 3 AND python 2

Cleaned up Pep 8 as reported by "jedi" lint & static analysis tool
prefer single quote, comment style
cleaned up windows issues
Translated to Python 3 by hand
Unicode, dropped "long", new module names, print as function, str.format()
functional code like map() return iterator rather than execute and return list

backported to python 2 with six.py

Unit tests run "OK" on Python 2 and Python 3 on windows and Linux 64 and 32 bit

Intend to use this branch regularly on software projects
This is about 4 days worth of work including a day of debugging
