### PR TITLE
Port to Python 2 and 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ specification is complete._
 The [PYPI](https://pypi.python.org/pypi) package is
 [`transit-python`](https://pypi.python.org/pypi/transit-python)
 
- * Latest stable release: [0.8](https://pypi.python.org/pypi/transit-python/0.8.174-)
+ * Latest stable release: [0.8](https://pypi.python.org/pypi/transit-python/0.8.180-)
 
 You can install with any of the following:
 
@@ -69,6 +69,7 @@ For example:
 ## Supported Python versions
 
  * 2.7.X
+ * 3.5.X
 
 
 ## Type Mapping
@@ -201,7 +202,7 @@ This library is open source, developed internally by Cognitect. We welcome discu
 
 ## Copyright and License
 
-Copyright © 2014 Cognitect
+Copyright © 2014-16 Cognitect
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ from setuptools import setup, find_packages
 import subprocess
 
 setup(name="transit-python",
-      version="0.8.279",
+      version="0.8.280",
       description="Transit marshalling for Python",
       author="Cognitect",
       url="https://github.com/cognitect/transit-python",

--- a/tests/exemplars_test.py
+++ b/tests/exemplars_test.py
@@ -17,8 +17,9 @@ import unittest
 # then import transit stuff
 from transit.reader import Reader, JsonUnmarshaler, MsgPackUnmarshaler
 from transit.writer import Writer
-from transit.transit_types import Keyword, Symbol, URI, frozendict, TaggedValue, Link, true, false
-from StringIO import StringIO
+from transit.transit_types import Keyword, Symbol, URI, frozendict, TaggedValue
+from transit.transit_types import Link, true, false
+from io import StringIO, BytesIO
 from transit.helpers import mapcat
 from helpers import ints_centered_on, hash_of_size, array_of_symbools
 from uuid import UUID
@@ -33,26 +34,26 @@ def exemplar(name, val):
     class ExemplarTest(ExemplarBaseTest):
 
         def test_json(self):
-            with open("../transit-format/examples/0.8/simple/" + name + ".json", 'r') as stream:
+            with open("../transit-format/examples/0.8/simple/" + name + ".json") as stream:
                 data = Reader(protocol="json").read(stream)
                 self.assertEqual(val, data)
 
         def test_msgpack(self):
-            with open("../transit-format/examples/0.8/simple/" + name + ".mp", 'r') as stream:
+            with open("../transit-format/examples/0.8/simple/" + name + ".mp", 'rb') as stream:
                 data = Reader(protocol="msgpack").read(stream)
                 self.assertEqual(val, data)
 
         def test_json_verbose(self):
-            with open("../transit-format/examples/0.8/simple/" + name + ".verbose.json", 'r') as stream:
+            with open("../transit-format/examples/0.8/simple/" + name + ".verbose.json") as stream:
                 data = Reader(protocol="json_verbose").read(stream)
                 self.assertEqual(val, data)
 
         def test_reencode_msgpack(self):
-            io = StringIO()
+            io = BytesIO()
             writer = Writer(io, protocol="msgpack")
             writer.write(val)
             s = io.getvalue()
-            io = StringIO(s)
+            io = BytesIO(s)
 
             reader = Reader(protocol="msgpack")
             newval = reader.read(io)
@@ -82,16 +83,16 @@ def exemplar(name, val):
             self.assertEqual(val, newval)
 
         def assertEqual(self, val, data):
-            try:
-                return unittest.TestCase.assertEqual(self, val, data)
-            except AssertionError as e:
-                if not False in [isnan(v) and isnan(d) or isnan(v) == isnan(d)
-                                 for v, d in zip (val, data)]:
-                    return unittest.TestCase.assertEqual(self, filter(lambda x: not isnan(x), val),
-                                                               filter(lambda x: not isnan(x), data))
-                else:
-                    e.args += (name, "failed")
-                    raise
+          if type(val) is float or type(data) is float:
+              if type(val) is float and type(data) is float and isnan(val) and isnan(data):
+                  return true
+              else:
+                  unittest.TestCase.assertAlmostEqual(self, val, data, places=7, msg=name)
+          elif type(val) in [list, tuple]:
+              for v, d in zip(val, data):
+                  self.assertEqual(v, d)
+          else:
+            unittest.TestCase.assertEqual(self,  val, data, name + " " +  str(val) + " vs " + str(data))
 
     globals()["test_" + name + "_json"] = ExemplarTest
 
@@ -111,6 +112,7 @@ UUIDS = (UUID('5a2cbea3-e8c6-428b-b525-21239370dd55'),
          UUID('d1dc64fa-da79-444b-9fa4-d4412f427289'),
          UUID('501a978e-3a3e-4060-b3be-1cf2bd4b1a38'),
          UUID('b3ba141a-a776-48e4-9fae-a28ea8571f58'))
+
 
 URIS = (
   URI(u'http://example.com'),
@@ -135,6 +137,8 @@ MAP_MIXED = frozendict({Keyword("a"): 1,
 
 MAP_NESTED = frozendict({Keyword("simple"): MAP_SIMPLE,
                          Keyword("mixed"): MAP_MIXED})
+
+exemplar("uris", URIS)
 
 exemplar("nil", None)
 exemplar("true", true)
@@ -180,11 +184,11 @@ exemplar("map_nested", MAP_NESTED)
 exemplar("map_string_keys", {"first": 1, "second": 2, "third": 3})
 exemplar("map_numeric_keys", {1: "one", 2: "two"})
 exemplar("map_vector_keys", frozendict([[(1, 1), "one"],
-                                        [(2, 2), "two"]]))
+                                         [(2, 2), "two"]]))
 
 
 exemplar("map_unrecognized_vals", {Keyword("key"): "~Unrecognized"})
-#exemplar("map_unrecognized_keys", )
+ #exemplar("map_unrecognized_keys", )
 exemplar("vector_unrecognized_vals", ("~Unrecognized",))
 exemplar("vector_1935_keywords_repeated_twice", tuple(array_of_symbools(1935, 1935*2)))
 exemplar("vector_1936_keywords_repeated_twice", tuple(array_of_symbools(1936, 1936*2)))
@@ -216,7 +220,7 @@ exemplar("maps_four_char_string_keys", ({"aaaa": 1, "bbbb": 2},
                                         {"aaaa": 5, "bbbb": 6}))
 
 exemplar("maps_unrecognized_keys", (TaggedValue("abcde", Keyword("anything")),
-                                   TaggedValue("fghij", Keyword("anything-else")),))
+                                    TaggedValue("fghij", Keyword("anything-else")),))
 
 exemplar("vector_special_numbers", (float("nan"), float("inf"), float("-inf")))
 
@@ -236,4 +240,3 @@ if __name__=='__main__':
     #p = pstats.Stats('exemptests')
     #p.sort_stats('time')
     #p.print_stats()
-

--- a/tests/exemplars_test.py
+++ b/tests/exemplars_test.py
@@ -230,7 +230,8 @@ exemplar("vector_special_numbers", (float("nan"), float("inf"), float("-inf")))
 def make_hash_exemplar(n):
     exemplar("map_%s_nested" % (n,), {Keyword("f"): hash_of_size(n),
                                       Keyword("s"): hash_of_size(n)})
-map(make_hash_exemplar, [10, 1935, 1936, 1937])
+for n in [10, 1935, 1936, 1937]:
+    make_hash_exemplar(n)
 
 if __name__=='__main__':
     unittest.main()

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -12,9 +12,10 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 
+import transit
 from transit.transit_types import Symbol, Keyword, frozendict
 from transit.helpers import cycle, take, pairs
-from itertools import izip
+from transit.pyversion import izip
 
 def ints_centered_on(m, n=5):
     return tuple(range(m - n, m + n + 1))

--- a/tests/regression.py
+++ b/tests/regression.py
@@ -19,8 +19,9 @@ from transit.reader import Reader
 from transit.writer import Writer
 from transit.class_hash import ClassDict
 from transit.transit_types import Symbol, frozendict, true, false, Keyword, Named
+from transit.pyversion import unicode_type
 from decimal import Decimal
-from StringIO import StringIO
+from io import BytesIO, StringIO
 
 class RegressionBaseTest(unittest.TestCase):
     pass
@@ -78,9 +79,9 @@ def json_int_boundary(value, expected_type):
     globals()["test_json_int_boundary_" + str(value)] = JsonIntBoundaryTest
 
 json_int_boundary(2**53-1, int)
-json_int_boundary(2**53, unicode)
+json_int_boundary(2**53, unicode_type)
 json_int_boundary(-2**53+1, int)
-json_int_boundary(-2**53, unicode)
+json_int_boundary(-2**53, unicode_type)
 
 class BooleanTest(unittest.TestCase):
     """Even though we're roundtripping transit_types.true and
@@ -91,7 +92,10 @@ class BooleanTest(unittest.TestCase):
     """
     def test_write_bool(self):
         for protocol in ("json", "json_verbose", "msgpack"):
-            io = StringIO()
+            if protocol is "msgpack":
+              io = BytesIO()
+            else:
+              io = StringIO()
             w = Writer(io, protocol)
             w.write((True, False))
             r = Reader(protocol)

--- a/tests/seattle_benchmark.py
+++ b/tests/seattle_benchmark.py
@@ -13,20 +13,22 @@
 ## limitations under the License.
 
 from transit.reader import JsonUnmarshaler
+from transit.pyversion import unicode_type
 import json
 import time
-from StringIO import StringIO
+from io import StringIO
+
 def run_tests(data):
-    datas = StringIO(data)
+    datas = StringIO(unicode_type(data))
     t = time.time()
     JsonUnmarshaler().load(datas)
     et = time.time()
-    datas = StringIO(data)
+    datas = StringIO(unicode_type(data))
     tt = time.time()
     json.load(datas)
     ett = time.time()
     read_delta = (et - t) * 1000.0
-    print "Done: " + str(read_delta) + "  --  raw JSON in: " + str((ett - tt) * 1000.0)
+    print("Done: " + str(read_delta) + "  --  raw JSON in: " + str((ett - tt) * 1000.0))
     return read_delta
 
 
@@ -42,10 +44,10 @@ for jsonfile in [seattle_dir + "example.json",
     print("Running " + jsonfile)
     print("-"*50)
 
-    runs = 100
+    runs = 200
     deltas = [run_tests(data) for x in range(runs)]
     means[jsonfile] = sum(deltas)/runs
 
 for jsonfile, mean in means.items():
-    print "\nMean for" + jsonfile + ": "+str(mean)
+    print("\nMean for" + jsonfile + ": "+str(mean))
 

--- a/transit/decoder.py
+++ b/transit/decoder.py
@@ -12,13 +12,14 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 
-import transit_types
-from constants import MAP_AS_ARR, ESC, SUB, RES
 from collections import OrderedDict
-from helpers import pairs
-import read_handlers as rh
-from rolling_cache import RollingCache, is_cacheable, is_cache_key
-from transit_types import true, false
+from transit import pyversion
+from transit import transit_types
+from transit.constants import MAP_AS_ARR, ESC, SUB, RES
+from transit.helpers import pairs
+from transit import read_handlers as rh
+from transit.rolling_cache import RollingCache, is_cacheable, is_cache_key
+from transit.transit_types import true, false
 
 
 class Tag(object):
@@ -83,8 +84,10 @@ class Decoder(object):
 
     def _decode(self, node, cache, as_map_key):
         tp = type(node)
-        if tp is unicode:
+        if tp is pyversion.unicode_type:
             return self.decode_string(node, cache, as_map_key)
+        elif tp is bytes:
+            return self.decode_string(node.decode("utf-8"), cache, as_map_key)
         elif tp is dict or tp is OrderedDict:
             return self.decode_hash(node, cache, as_map_key)
         elif tp is list:
@@ -150,7 +153,8 @@ class Decoder(object):
                 h[key] = val
             return transit_types.frozendict(h)
         else:
-            key, value = hash.items()[0]
+            key = list(hash)[0]
+            value = hash[key]
             key = self._decode(key, cache, True)
             if isinstance(key, Tag):
                 return self.decode_tag(key.tag,

--- a/transit/helpers.py
+++ b/transit/helpers.py
@@ -13,14 +13,15 @@
 ## limitations under the License.
 
 import itertools
+from transit.pyversion import imap, izip
 
 
 def mapcat(f, i):
-    return itertools.chain.from_iterable(itertools.imap(f, i))
+    return itertools.chain.from_iterable(imap(f, i))
 
 
 def pairs(i):
-    return itertools.izip(*[iter(i)] * 2)
+    return izip(*[iter(i)] * 2)
 
 
 cycle = itertools.cycle

--- a/transit/pyversion.py
+++ b/transit/pyversion.py
@@ -1,0 +1,54 @@
+## Copyright 2014 Cognitect. All Rights Reserved.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS-IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+
+import sys
+
+PY3 = sys.version_info[0] == 3
+PY2 = sys.version_info[0] == 2
+
+if PY3:
+  unicode_type = str
+  unicode_f = chr
+  string_types = [str]
+else:
+  string_types = [str, unicode]
+  unicode_type = unicode
+  unicode_f = unichr
+
+isstring = lambda s : type(s) in string_types
+
+if PY3:
+  long_type = int
+  int_type = int
+  int_types = [int]
+  number_types = [int, float]
+else:
+  long_type = long
+  int_type = int
+  int_types = [long, int]
+  number_types = [long, int, float]
+
+isint = lambda i : type(i) in int_types
+isnumber = lambda i : type(i) in number_types
+isnumber_type = lambda t : t in number_types
+
+if PY3:
+  imap = map
+  izip = zip
+  iteritems = lambda d, **kw: d.items(**kw)
+else:
+  import itertools
+  imap = itertools.imap
+  izip = itertools.izip
+  iteritems = lambda d, **kw: d.iteritems(**kw)

--- a/transit/read_handlers.py
+++ b/transit/read_handlers.py
@@ -12,13 +12,14 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 
-import transit_types
+from transit import pyversion
+from transit import transit_types
 import uuid
 import ctypes
 import dateutil.parser
 import datetime
 import dateutil.tz
-from helpers import pairs
+from transit.helpers import pairs
 from decimal import Decimal
 
 ## Read handlers are used by the decoder when parsing/reading in Transit
@@ -58,6 +59,7 @@ class BigDecimalHandler(object):
 class BooleanHandler(object):
     @staticmethod
     def from_rep(x):
+        print("*****Bool:", x)
         return transit_types.true if x == "t" else transit_types.false
 
 
@@ -77,7 +79,7 @@ class UuidHandler(object):
     @staticmethod
     def from_rep(u):
         """Given a string, return a UUID object."""
-        if isinstance(u, basestring):
+        if pyversion.isstring(u):
             return uuid.UUID(u)
 
         # hack to remove signs
@@ -96,11 +98,11 @@ class UriHandler(object):
 class DateHandler(object):
     @staticmethod
     def from_rep(d):
-        if isinstance(d, (long, int)):
+        if pyversion.isint(d):
             return DateHandler._convert_timestamp(d)
         if "T" in d:
             return dateutil.parser.parse(d)
-        return DateHandler._convert_timestamp(long(d))
+        return DateHandler._convert_timestamp(pyversion.long_type(d))
 
     @staticmethod
     def _convert_timestamp(ms):
@@ -108,10 +110,16 @@ class DateHandler(object):
         return datetime.datetime.fromtimestamp(ms/1000.0, dateutil.tz.tzutc())
 
 
-class BigIntegerHandler(object):
-    @staticmethod
-    def from_rep(d):
-        return long(d)
+if pyversion.PY3:
+    class BigIntegerHandler(object):
+        @staticmethod
+        def from_rep(d):
+            return int(d)
+else:
+    class BigIntegerHandler(object):
+        @staticmethod
+        def from_rep(d):
+            return long(d)
 
 
 class LinkHandler(object):

--- a/transit/read_handlers.py
+++ b/transit/read_handlers.py
@@ -59,7 +59,6 @@ class BigDecimalHandler(object):
 class BooleanHandler(object):
     @staticmethod
     def from_rep(x):
-        print("*****Bool:", x)
         return transit_types.true if x == "t" else transit_types.false
 
 

--- a/transit/reader.py
+++ b/transit/reader.py
@@ -13,10 +13,10 @@
 ## limitations under the License.
 
 import json
-import sosjson
 import msgpack
-from decoder import Decoder
 from collections import OrderedDict
+from transit import sosjson
+from transit.decoder import Decoder
 
 
 class Reader(object):

--- a/transit/rolling_cache.py
+++ b/transit/rolling_cache.py
@@ -12,7 +12,7 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 
-from constants import SUB, MAP_AS_ARR
+from transit.constants import SUB, MAP_AS_ARR
 
 FIRST_ORD = 48
 CACHE_CODE_DIGITS = 44

--- a/transit/transit_types.py
+++ b/transit/transit_types.py
@@ -13,6 +13,7 @@
 ## limitations under the License.
 
 from collections import Mapping, Hashable
+from transit.pyversion import isstring, unicode_f, unicode_type
 
 
 class Named(object):
@@ -38,7 +39,7 @@ class Named(object):
 
 class Keyword(Named):
     def __init__(self, value):
-        assert isinstance(value, basestring)
+        assert isstring(value)
         self.str = value
         self.hv = value.__hash__()
 
@@ -63,7 +64,7 @@ class Keyword(Named):
 
 class Symbol(Named):
     def __init__(self, value):
-        assert isinstance(value, basestring)
+        assert isstring(value)
         self.str = value
         self.hv = value.__hash__()
 
@@ -157,7 +158,8 @@ class List(TaggedValue):
 
 class URI(TaggedValue):
     def __init__(self, rep):
-        TaggedValue.__init__(self, "uri", rep)
+        # works p3 TaggedValue.__init__(self, "uri", (unicode(rep)))
+        TaggedValue.__init__(self, "uri", (rep))
 
 
 class frozendict(Mapping, Hashable):
@@ -252,6 +254,9 @@ class Boolean(object):
         self.v = True if name == "true" else False
         self.name = name
 
+    def __bool__(self):
+      return self.v
+
     def __nonzero__(self):
         return self.v
 
@@ -262,5 +267,6 @@ class Boolean(object):
         return self.name
 
 # lowercase rep matches java/clojure
+
 false = Boolean("false")
 true = Boolean("true")

--- a/transit/write_handlers.py
+++ b/transit/write_handlers.py
@@ -15,11 +15,15 @@
 import uuid
 import datetime
 import struct
-from class_hash import ClassDict
-from transit_types import Keyword, Symbol, URI, frozendict, TaggedValue, Link, Boolean
+from transit import pyversion
+from transit.class_hash import ClassDict
+from transit.transit_types import Keyword, Symbol, URI, frozendict, TaggedValue, Link, Boolean
 from decimal import Decimal
 from dateutil import tz
 from math import isnan
+
+MAX_INT = 2**63 - 1
+MIN_INT = -2**63
 
 ## This file contains Write Handlers - all the top-level objects used when
 ## writing Transit data.  These object must all be immutable and pickleable.
@@ -77,6 +81,21 @@ class BigIntHandler(object):
     @staticmethod
     def rep(n):
         return str(n)
+
+    @staticmethod
+    def string_rep(n):
+        return str(n)
+
+class Python3IntHandler(object):
+    @staticmethod
+    def tag(n):
+      if n < MAX_INT and n > MIN_INT:
+        return "i"
+      return "n"
+
+    @staticmethod
+    def rep(n):
+        return n
 
     @staticmethod
     def string_rep(n):
@@ -321,13 +340,18 @@ class WriteHandler(ClassDict):
         self[bool] = BooleanHandler
         self[Boolean] = BooleanHandler
         self[str] = StringHandler
-        self[unicode] = StringHandler
+        self[pyversion.unicode_type] = StringHandler
         self[list] = ArrayHandler
         self[tuple] = ArrayHandler
         self[dict] = MapHandler
-        self[int] = IntHandler
+
+        if pyversion.PY3:
+          self[int] = Python3IntHandler
+        else:
+          self[int] = IntHandler
+          self[long] = BigIntHandler
+
         self[float] = FloatHandler
-        self[long] = BigIntHandler
         self[Keyword] = KeywordHandler
         self[Symbol] = SymbolHandler
         self[uuid.UUID] = UuidHandler


### PR DESCRIPTION
These modification allow transit-python to work with both Python 2 and Python 3.
Much of this work was inspired and/or copied from this pull request:

   https://github.com/cognitect/transit-python/pull/26

By dand-oss (https://github.com/dand-oss).

The differences are:
- These changes try to minimize the number of dependencies by dealing with the Python 2 / Python 3
  differences in the transit code instead of relying on six.py. See transit/pyversion.py.
- Focusing purely on the Python version issues and omitting many of the code style and other changes. 
  The Python version issues are more than enough for one pull request. I hope that we can consider 
  these additional updates after we have the version lion tamed.
- Ensuring that the tests pass under both Python versions.

The main outstanding issue even after this pull request is that the transit-format/bin/verify integration test does not pass for message pack. This seems to be a timing/sync problem in the pipe communications used. This problem also occurs in the current transit-python.
